### PR TITLE
Check in handleCall and doHook

### DIFF
--- a/viv_utils/emulator_drivers.py
+++ b/viv_utils/emulator_drivers.py
@@ -228,17 +228,6 @@ class EmulatorDriver(object):
 
         emu = self._emu
 
-        targetOpnd = op.getOperands()[0]
-
-        # fetch `target` that is the VA of the function
-        if targetOpnd.isDeref():
-            # maybe call through IAT, like: call [0x10008050]
-            # fetch the "0x10008050"
-            target = targetOpnd.getOperAddr(op, emu)
-        else:
-            # like: call 0x10008050, probably not an import
-            target = targetOpnd.getOperValue(op, emu)
-
         emu.executeOpcode(op)
         endpc = emu.getProgramCounter()
 

--- a/viv_utils/emulator_drivers.py
+++ b/viv_utils/emulator_drivers.py
@@ -154,8 +154,13 @@ class EmulatorDriver(object):
 
         api = emu.getCallApi(pc)
         rtype, rname, convname, callname, funcargs = api
-        callconv = emu.getCallingConvention(convname)
-        argv = callconv.getCallArgs(emu, len(funcargs))
+        if convname:
+            callconv = emu.getCallingConvention(convname)
+        else:
+            callconv = emu.getCallingConventions()[0][1]  # use as default
+        argv = []
+        if callconv:
+            argv = callconv.getCallArgs(emu, len(funcargs))
 
         # attempt to invoke hooks to handle function calls.
         # priority:
@@ -239,8 +244,10 @@ class EmulatorDriver(object):
 
         api = emu.getCallApi(endpc)
         rtype, rname, convname, callname, funcargs = api
-        callconv = emu.getCallingConvention(convname)
-        argv = callconv.getCallArgs(emu, len(funcargs))
+        if convname:
+            callconv = emu.getCallingConvention(convname)
+        else:
+            callconv = emu.getCallingConventions()[0][1]  # use as default
 
         if self.doHook(endpc, op):
             # some hook handled the call,

--- a/viv_utils/emulator_drivers.py
+++ b/viv_utils/emulator_drivers.py
@@ -157,7 +157,7 @@ class EmulatorDriver(object):
         if convname:
             callconv = emu.getCallingConvention(convname)
         else:
-            callconv = emu.getCallingConventions()[0][1]  # use as default
+            callconv = emu.getCallingConvention("stdcall")
         argv = []
         if callconv:
             argv = callconv.getCallArgs(emu, len(funcargs))
@@ -236,7 +236,7 @@ class EmulatorDriver(object):
         if convname:
             callconv = emu.getCallingConvention(convname)
         else:
-            callconv = emu.getCallingConventions()[0][1]  # use as default
+            callconv = emu.getCallingConvention("stdcall")
 
         if self.doHook(endpc, op):
             # some hook handled the call,


### PR DESCRIPTION
Check available calling convention and argv before using them. Set default values, if no call API is available.