### PR TITLE
remove ipython from requirements

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,6 @@ requirements = [
     "funcy",
     "argparse",
     "pefile",
-    "ipython",
     "vivisect",
     "intervaltree",
 ]


### PR DESCRIPTION
`viv-utils` does not actually require `ipython`. I saw in a recent Travis log for FLOSS (https://travis-ci.org/fireeye/flare-floss/jobs/224003494) that ` IPython 6.0+ does not support Python 2.6, 2.7, 3.0, 3.1, or 3.2` anymore.
If you still want to keep the requirement for convenience, I can change it to `'ipython==5.3.0'`.

Related, I think `viv-utils` does not require `argparse` and `pefile` either. Let me know if you want me to remove them.