### PR TITLE
Update setup.py and fix last release

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ requirements = [
 
 setuptools.setup(
     name='viv_utils',
-    version='0.3.17',
+    version='0.3.18',
     description="Utilities for binary analysis using vivisect.",
     long_description="Utilities for binary analysis using vivisect.",
     author="Willi Ballenthin",

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ setuptools.setup(
     long_description="Utilities for binary analysis using vivisect.",
     author="Willi Ballenthin",
     author_email='william.ballenthin@mandiant.com',
-    url='https://github.mandiant.com/wballenthin/viv-utils',
+    url='https://github.com/williballenthin/viv-utils',
     packages=setuptools.find_packages(),
     package_dir={'viv_utils':'viv_utils'},
     package_data={'viv_utils': ['data/*.py']},

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ requirements = [
 
 setuptools.setup(
     name='viv_utils',
-    version='0.3.18',
+    version='0.3.19',
     description="Utilities for binary analysis using vivisect.",
     long_description="Utilities for binary analysis using vivisect.",
     author="Willi Ballenthin",


### PR DESCRIPTION
Uploading viv-utils to pypi failed because the version already existed:
https://github.com/williballenthin/viv-utils/runs/1856797466

The v0.3.18 release should be updated after this PR is merged.

Also update project url.