### PR TITLE
Do not used e.message

### DIFF
--- a/viv_utils/__init__.py
+++ b/viv_utils/__init__.py
@@ -186,7 +186,7 @@ class BasicBlock(LoggingObject):
             try:
                 o = self.vw.parseOpcode(va)
             except Exception as e:
-                self.d("Failed to disassemble: %s: %s", hex(va), e.message)
+                self.d("Failed to disassemble: %s: %s", hex(va), e)
                 break
             ret.append(o)
             va += len(o)


### PR DESCRIPTION
The `message` attribute on BaseException was deprecated in Python 2.6 and removed in Python 3:
https://www.python.org/dev/peps/pep-0352/#retracted-ideas

Stop using the `message` method to prepare for the migration of vivisect to Python3.