### PR TITLE
python3: warn incompatible .viv

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ if sys.version_info >= (3, 0):
 
 setuptools.setup(
     name='viv_utils',
-    version='0.4.1',
+    version='0.5.0',
     description="Utilities for binary analysis using vivisect.",
     long_description="Utilities for binary analysis using vivisect.",
     author="Willi Ballenthin",


### PR DESCRIPTION
A common problem when migrating from Python 2 to Python 3 is that `vw.loadWorkspace(viv_file)` raises an `UnicodeDecodeError` exception because `.viv` files generated with Python 2 are incompatible with Python 3 (encoding differences). Provide a more descriptive exception in this case.

We should release v0.5.0 to be able to use this change in capa.

Related: https://github.com/fireeye/capa/issues/469