### PR TITLE
Bug fix for is_x64 and support for IDA 9.0

### DIFF
--- a/viv_utils/idaloader.py
+++ b/viv_utils/idaloader.py
@@ -44,8 +44,12 @@ def is_x86():
     """
     is the currently loaded module 32-bit x86?
     """
-    inf = idaapi.get_inf_structure()
-    return inf.procname == "metapc" and inf.is_32bit() and not inf.is_64bit()
+    try:
+        inf = idaapi.get_inf_structure()
+        procname = inf.procname
+    except AttributeError:
+        procname = ida_ida.inf_get_procname()
+    return procname == "metapc" and ida_ida.inf_is_32bit_exactly() and not ida_ida.inf_is_64bit()
 
 
 @requires_ida
@@ -53,8 +57,12 @@ def is_x64():
     """
     is the currently loaded module 64-bit x86?
     """
-    inf = idaapi.get_inf_structure()
-    return inf.procName == "metapc" and inf.is_32bit() and inf.is_64bit()
+    try:
+        inf = idaapi.get_inf_structure()
+        procname = inf.procname
+    except AttributeError:
+        procname = ida_ida.inf_get_procname()
+    return procName == "metapc" and not ida_ida.inf_is_32bit_exactly() and ida_ida.inf_is_64bit()
 
 
 @requires_ida


### PR DESCRIPTION
- is_x64 function should not be 32-bit but be 64-bit. So I added "not" for is_32bit.
- On IDA 9.0, get_inf_structure has been removed. To support it, we need to replace the function.